### PR TITLE
Fix broken links in regions blog

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           repository: xataio/website
           # TODO: Change branch to "main" once we have a stable release
-          ref: ${{ inputs.branch || 'missing-mdx-compile' }}
+          ref: ${{ inputs.branch || 'docs_migration' }}
           token: ${{ secrets.GIT_TOKEN }}
 
       - uses: actions/setup-node@v3

--- a/introducing-new-xata-regions-sydney-frankfurt.mdx
+++ b/introducing-new-xata-regions-sydney-frankfurt.mdx
@@ -39,4 +39,4 @@ By extending our Xata regions to include additional locations in the Pacific and
 
 Exciting plans for the future lie ahead as we continue to expand our offerings, with additional regions in the pipeline. Our goal is to continually enhance the Xata platform, empowering developers and businesses worldwide to leverage the full potential of PostgreSQL databases in a serverless environment. We believe in fostering a collaborative and supportive developer community, and your feedback is essential in shaping the future of our platform. Your support and participation are appreciated, and we're excited to hear about your experiences working with the new regions. Your insights and observations are crucial in helping us provide the best possible experience.
 
-If you have any questions, suggestions, or just want to share your Xata stories, please don't hesitate to get in touch with us either on [Discord](xata.io/discord) or [Twitter](http://twitter.com/xata).
+If you have any questions, suggestions, or just want to share your Xata stories, please don't hesitate to get in touch with us either on [Discord](https://xata.io/discord) or [Twitter](https://twitter.com/xata).


### PR DESCRIPTION
Noticed a couple broken links when fixing them in the docs. This will also make the previews work, now that I've merged a docs branch down.