### PR TITLE
One preview build at a time

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,9 @@
-name: Docs preview
+name: Blog preview
+
+# https://stackoverflow.com/a/72408109
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -83,7 +83,7 @@ jobs:
             --token ${{ secrets.VERCEL_TOKEN }} \
             --scope team_lMj2cFnO13wwm6LWz3X5kulx \
             --safe \
-            -- yes \
+            --yes \
             $(cat deploy_url.txt)
         env:
           VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,6 +19,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
+      VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU
+
     steps:
       - name: Checkout website repo
         uses: actions/checkout@v3
@@ -46,9 +50,6 @@ jobs:
             --build-env XATA_BRANCH=main \
             --env XATA_BRANCH=main \
             > deploy_url.txt
-        env:
-          VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
-          VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU
 
       - name: Get deployment URL
         id: get-url
@@ -81,10 +82,7 @@ jobs:
         run: |
           vercel remove \
             --token ${{ secrets.VERCEL_TOKEN }} \
-            --scope team_lMj2cFnO13wwm6LWz3X5kulx \
+            --scope $VERCEL_ORG_ID \
             --safe \
             --yes \
             $(cat deploy_url.txt)
-        env:
-          VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
-          VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           vercel remove \
             --token ${{ secrets.VERCEL_TOKEN }} \
+            --scope team_lMj2cFnO13wwm6LWz3X5kulx
             $(cat deploy_url.txt)
         env:
           VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,9 +13,6 @@ on:
         description: 'Website branch to build from'
         default: 'main'
         type: string
-env:
-  VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
-  VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU
 
 jobs:
   build:
@@ -50,8 +47,8 @@ jobs:
             --env XATA_BRANCH=main \
             > deploy_url.txt
         env:
-          VERCEL_ORG_ID: $VERCEL_ORG_ID
-          VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID
+          VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
+          VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU
 
       - name: Get deployment URL
         id: get-url
@@ -86,5 +83,5 @@ jobs:
             --token ${{ secrets.VERCEL_TOKEN }} \
             $(cat deploy_url.txt)
         env:
-          VERCEL_ORG_ID: $VERCEL_ORG_ID
-          VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID
+          VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
+          VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           vercel remove \
             --token ${{ secrets.VERCEL_TOKEN }} \
-            --scope team_lMj2cFnO13wwm6LWz3X5kulx
+            --scope team_lMj2cFnO13wwm6LWz3X5kulx \
             $(cat deploy_url.txt)
         env:
           VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -75,3 +75,10 @@ jobs:
           edit-mode: replace
           body: |
             Check out the preview at ${{ steps.get-url.outputs.URL }}
+
+      - name: Job cancelled
+        if: ${{ cancelled() }}
+        run: |
+          vercel remove \
+            --token ${{ secrets.VERCEL_TOKEN }} \
+            $(cat deploy_url.txt)

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -82,6 +82,8 @@ jobs:
           vercel remove \
             --token ${{ secrets.VERCEL_TOKEN }} \
             --scope team_lMj2cFnO13wwm6LWz3X5kulx \
+            --safe \
+            -- yes \
             $(cat deploy_url.txt)
         env:
           VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,9 @@ on:
         description: 'Website branch to build from'
         default: 'main'
         type: string
+env:
+  VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
+  VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU
 
 jobs:
   build:
@@ -46,9 +49,6 @@ jobs:
             --build-env XATA_BRANCH=main \
             --env XATA_BRANCH=main \
             > deploy_url.txt
-        env:
-          VERCEL_ORG_ID: team_lMj2cFnO13wwm6LWz3X5kulx
-          VERCEL_PROJECT_ID: prj_7fENPf4qHhMCnz6j2IGYWDUkJ9wU
 
       - name: Get deployment URL
         id: get-url
@@ -76,7 +76,7 @@ jobs:
           body: |
             Check out the preview at ${{ steps.get-url.outputs.URL }}
 
-      - name: Job cancelled
+      - name: If job cancelled
         if: ${{ cancelled() }}
         run: |
           vercel remove \

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -49,6 +49,9 @@ jobs:
             --build-env XATA_BRANCH=main \
             --env XATA_BRANCH=main \
             > deploy_url.txt
+        env:
+          VERCEL_ORG_ID: $VERCEL_ORG_ID
+          VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID
 
       - name: Get deployment URL
         id: get-url
@@ -82,3 +85,6 @@ jobs:
           vercel remove \
             --token ${{ secrets.VERCEL_TOKEN }} \
             $(cat deploy_url.txt)
+        env:
+          VERCEL_ORG_ID: $VERCEL_ORG_ID
+          VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID


### PR DESCRIPTION
If multiple commits are pushed to the same PR, then the last one 'wins' and earlier github builds are cancelled.

If a github build is cancelled, then the vercel build is 'removed'. 

This keeps the number of concurrent builds we do on vercel down and should mean faster previews.