### PR TITLE
Publish Indexing File Attachments

### DIFF
--- a/indexing-files-with-python.mdx
+++ b/indexing-files-with-python.mdx
@@ -5,8 +5,8 @@
    src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/index-file-attachments.jpg
    alt: 'Extracting text from File Attachments and indexing it with Python.'
  author: Kostas Botsas
- date: 09-13-2023
- published: false
+ date: 09-14-2023
+ published: true
  slug: index-files-with-python
  ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/index-file-attachments.jpg
 ---
@@ -48,12 +48,12 @@ Here are the essential steps for running this script:
 
 1. Clone the xtools repo:
   ```bash
-  git clone https://github.com/xataio/xtools`
+  git clone https://github.com/xataio/xtools
   ```
   This repo is a library of open source helper scripts provided by Xata, but we welcome community contributions.
 2. Navigate to the directory:
   ```bash
-  cd xtools/xfileindex`
+  cd xtools/xfileindex
   ```
 3. Install the required packages using pip:
   ```bash


### PR DESCRIPTION
Final edits and publishing the "Indexing File Attachments with the Python SDK" blog post.

https://xata.io/blog/index-files-with-python