### PR TITLE
Cleanup the Postgres tag

### DIFF
--- a/database-nightmares.mdx
+++ b/database-nightmares.mdx
@@ -7,7 +7,7 @@ image:
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/database-horrors.jpg
 author: J Edwards
 date: 10-30-2023
-tags: ['postgres', 'postgreSQL', 'engineering']
+tags: ['engineering']
 published: true
 slug: database-horrors
 ---

--- a/sql-mysql-postgresql-nosql.mdx
+++ b/sql-mysql-postgresql-nosql.mdx
@@ -6,7 +6,7 @@ image:
   alt: Comparison of database options
 author: J Edwards
 date: 07-25-2023
-tags: ['postgres', 'sql']
+tags: ['sql']
 published: true
 slug: sql-mysql-postgresql-nosql
 ---

--- a/sql-over-http.mdx
+++ b/sql-over-http.mdx
@@ -3,7 +3,7 @@ title: 'SQL over HTTP and ORM integrations'
 description: 'Query PostgreSQL directly with SQL over HTTP in our REST API and SDKs'
 author: Noémi Ványi
 date: 08-31-2023
-tags: ['postgres', 'sql']
+tags: ['sql']
 published: true
 image:
   src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/intro-sql-access-over-http-cover.jpg


### PR DESCRIPTION
As I want to submit our Postgres tag RSS feed to [Planet PostgreSQL](https://planet.postgresql.org/), I want to make sure we only have blog posts in that tag that are directly related to PostgreSQL and interesting to that audience.