### PR TITLE
Add email address to the postgres blog posts

### DIFF
--- a/blog.schema.yaml
+++ b/blog.schema.yaml
@@ -14,6 +14,11 @@ properties:
     description: Author of the blog post
     type: string
     maxLength: 300
+  authorEmail:
+    title: authorEmail
+    description: Email of the author
+    type: string
+    maxLength: 300
   date:
     title: date
     description: Date of post

--- a/introducing-pgroll.mdx
+++ b/introducing-pgroll.mdx
@@ -5,6 +5,7 @@ image:
   src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/introducing-pgroll.jpg
   alt: pgroll
 author: Carlos Pérez-Aradros Herce
+authorEmail: carlos@xata.io
 date: 10-3-2023
 tags: ['open-source', 'postgres']
 published: true

--- a/pgroll-internals.mdx
+++ b/pgroll-internals.mdx
@@ -5,8 +5,9 @@ image:
   src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-internal.jpeg
   alt: pgroll
 author: Andrew Farries
+authorEmail: andrew@xata.io
 date: 11-30-2023
-tags: ['open-source', 'postgres', 'postgresql', 'schema', 'engineering', 'product']
+tags: ['open-source', 'postgres', 'schema', 'engineering', 'product']
 published: true
 slug: pgroll-internals
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-internal.jpeg

--- a/postgres-full-text-search-engine.mdx
+++ b/postgres-full-text-search-engine.mdx
@@ -5,6 +5,7 @@ image:
   src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/postgres-full-text-search.png
   alt: Postgres full-text search
 author: Tudor Golubenco
+authorEmail: tudor@xata.io
 tags: ['engineering', 'postgres', 'search']
 date: 07-12-2023
 published: true

--- a/postgres-full-text-search-postgres-vs-elasticsearch.mdx
+++ b/postgres-full-text-search-postgres-vs-elasticsearch.mdx
@@ -5,6 +5,7 @@ image:
   src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/postgres-vs-elasticsearch-full-text-search.png
   alt: Postgres vs Elasticsearch for full-text search
 author: Tudor Golubenco
+authorEmail: tudor@xata.io
 date: 07-19-2023
 tags: ['engineering', 'postgres', 'search']
 published: true

--- a/postgres-schema-changes-pita.mdx
+++ b/postgres-schema-changes-pita.mdx
@@ -5,6 +5,7 @@ image:
   src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/postgres-schema-changes.png
   alt: Posgres schema changes
 author: Tudor Golubenco
+authorEmail: tudor@xata.io
 date: 06-29-2023
 tags: ['engineering', 'postgres']
 published: true

--- a/replica-identity-full-performance.mdx
+++ b/replica-identity-full-performance.mdx
@@ -5,6 +5,7 @@ image:
   src: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/performance-of-replica-identity-full.png
   alt: Performance of REPLICA IDENTITY FULL
 author: Tudor Golubenco
+authorEmail: tudor@xata.io
 date: 06-07-2023
 tags: [engineering', 'postgres']
 published: true


### PR DESCRIPTION
Adds email addresses to the blog posts tagged `postgres`, so that they can be aggregated via Planet Postgres.