### PR TITLE
Add `fpPgstream` tags to feature posts on future pgstream page

### DIFF
--- a/pgzx-update-0.2.0.mdx
+++ b/pgzx-update-0.2.0.mdx
@@ -7,7 +7,7 @@ image:
 author: Steffen Siering
 authorEmail: steffen@xata.io
 date: 07-19-2024
-tags: ['open-source', 'postgres', 'fpPgzx', 'oss']
+tags: ['open-source', 'postgres', 'fpPgzx', 'oss', 'fpPgstream']
 published: true
 slug: pgzx-update-0.2.0
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgzx-update-0-2-0@2x.jpg

--- a/whats-new-in-pgroll-0-6-0.mdx
+++ b/whats-new-in-pgroll-0-6-0.mdx
@@ -7,7 +7,7 @@ image:
 author: Andrew Farries
 authorEmail: andrew@xata.io
 date: 07-19-2024
-tags: ['open-source', 'postgres', 'schema', 'migrations', 'pgroll', 'fpSchemaMigrations', 'oss']
+tags: ['open-source', 'postgres', 'schema', 'migrations', 'pgroll', 'fpSchemaMigrations', 'oss', 'fpPgstream']
 published: true
 slug: pgroll-0-6-0-update
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-update-0-6-0@2x.jpg


### PR DESCRIPTION
## Summary

This PR adds `fpPgstream` tags to two blog posts so that they can be featured on the future pgstream page (https://github.com/xataio/frontend-next/pull/3674).

### Blog Release Checklist

- \[ ] Release on: \<mm/dd/yy>
- \[ ] Published on dev.to (connected to Xata org)
- \[ ] OG image included
- \[ ] Social media is scheduled for this post
