### PR TITLE
Add alert status to `postgresql-dedicated-clusters-beta`

### DIFF
--- a/postgresql-dedicated-clusters-beta.mdx
+++ b/postgresql-dedicated-clusters-beta.mdx
@@ -13,6 +13,8 @@ slug: postgresql-dedicated-clusters-beta
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/postgresql-dedicated-clusters-beta/dedicated-clusters.jpg
 ---
 
+<Alert status="error">Update: The offer of free credits is no longer available</Alert>
+
 Earlier this year we announced our [serverless Postgres platform](https://xata.io/blog/serverless-postgres-platform) and an early access program for [dedicated clusters](https://xata.io/blog/postgres-dedicated-clusters). Both of these offerings are core to Xata's evolution to becoming a Postgres database platform for faster development and a worry-free data layer. Serverless Postgres unlocks decades worth of community, tooling and support for our customers. While dedicated clusters provide more predictable costs, better performance and a more scalable solution for large production workloads. The two pair perfectly together, and we'll be diving into what's new in this blog.
 
 We're extremely excited to announce the next milestone in this evolution, our public beta for dedicated clusters 🎉


### PR DESCRIPTION
## Summary

This PR adds an alert status to `postgresql-dedicated-clusters-beta` post: "Update: The offer of free credits is no longer available"

### Preview

https://xata-blog-pr-325.vercel.app/blog/postgresql-dedicated-clusters-beta
