### PR TITLE
Update `pgroll` docs links

### DIFF
--- a/pgroll-integration.mdx
+++ b/pgroll-integration.mdx
@@ -50,7 +50,7 @@ When using a Postgres enabled database, there will be new options to edit column
 
 ![New edit column functionality](/images/pgroll-integration/edit.png)
 
-There will also be a new tab called Migration Editor on the Schema view page. Users can now run numerous arbitrary migrations with type safe completions, from additive changes like creating new columns, to destructive changes like changing column types. All operations supported can be found [here](https://github.com/xataio/pgroll/tree/main/docs#operations-reference) with a long list of examples [here](https://github.com/xataio/pgroll/tree/main/examples).
+There will also be a new tab called Migration Editor on the Schema view page. Users can now run numerous arbitrary migrations with type safe completions, from additive changes like creating new columns, to destructive changes like changing column types. All operations supported can be found [here](https://github.com/xataio/pgroll/blob/main/docs/operations-reference.md) with a long list of examples [here](https://github.com/xataio/pgroll/tree/main/examples).
 
 ![New Migration Editor](/images/pgroll-integration/editor.png)
 

--- a/whats-new-in-pgroll-0-6-0.mdx
+++ b/whats-new-in-pgroll-0-6-0.mdx
@@ -60,7 +60,7 @@ As of `v0.6.0`, `pgroll` will now run all DDL operations before running any data
 
 Changing a column default is a versioned operation so the column to which the new default is applied is duplicated and backfilled according to the `up` and `down` SQL supplied with the 'alter column' operation. `up` and `down` default to a simple copy of the field between new and old columns.
 
-See the documentation for the [alter column operation](https://github.com/xataio/pgroll/tree/main/docs#change-default) for more information.
+See the documentation for the [alter column operation](https://github.com/xataio/pgroll/blob/main/docs/operations-reference.md#change-default) for more information.
 
 ### Changing multiple column properties in one operation
 
@@ -95,7 +95,7 @@ A migration that changes multiple column properties in one operation looks like 
 }
 ```
 
-See the documentation for the [alter column operation](https://github.com/xataio/pgroll/tree/main/docs#alter-column) for more information.
+See the documentation for the [alter column operation](https://github.com/xataio/pgroll/blob/main/docs/operations-reference.md#alter-column) for more information.
 
 ### Renaming constraints
 
@@ -116,7 +116,7 @@ Perhaps it's a smaller change than others listed here, but the ability to rename
 }
 ```
 
-See the documentation for the [rename constraint operation](https://github.com/xataio/pgroll/tree/main/docs#rename-constraint) for more information.
+See the documentation for the [rename constraint operation](https://github.com/xataio/pgroll/blob/main/docs/operations-reference.md#rename-constraint) for more information.
 
 ### Running raw SQL migrations on completion
 
@@ -140,7 +140,7 @@ In versions of `pgroll` before `v0.6.0`, SQL migrations would always be run on m
 
 The ability to run a raw SQL migration on completion allows the SQL statement to reference the versioned views that `pgroll` creates for any non raw SQL operations in the same migration.
 
-See the documentation for the [raw SQL operation](https://github.com/xataio/pgroll/tree/main/docs#raw-sql) for more information.
+See the documentation for the [raw SQL operation](https://github.com/xataio/pgroll/blob/main/docs/operations-reference.md#raw-sql) for more information.
 
 ## Using pgroll as a module
 

--- a/whats-new-in-pgroll-0-7-0.mdx
+++ b/whats-new-in-pgroll-0-7-0.mdx
@@ -55,7 +55,7 @@ Controlling the rate of the backfill can be useful in scenarios where the databa
 
 ### Partial index support
 
-As of `v0.7.0`, `pgroll` supports [partial indexes](https://www.postgresql.org/docs/current/indexes-partial.html) as part of the [create_index](https://github.com/xataio/pgroll/blob/main/docs/README.md#create-index) operation by specifying a `predicate` field:
+As of `v0.7.0`, `pgroll` supports [partial indexes](https://www.postgresql.org/docs/current/indexes-partial.html) as part of the [create_index](https://github.com/xataio/pgroll/blob/main/docs/operations-reference.md#create-index) operation by specifying a `predicate` field:
 
 ```json
 {

--- a/zero-downtime-schema-migrations-postgresql.mdx
+++ b/zero-downtime-schema-migrations-postgresql.mdx
@@ -108,7 +108,7 @@ If you're interested in learning more about why we built this solution, how it's
 
 ## Coming soon to Xata
 
-We are in the process of integrating pgroll directly to Xata. This will open the door to [many more migrations](https://github.com/xataio/pgroll/tree/main/docs#operations-reference) that can be rolled out in production, with zero downtime.
+We are in the process of integrating pgroll directly to Xata. This will open the door to [many more migrations](https://github.com/xataio/pgroll/blob/main/docs/operations-reference.md) that can be rolled out in production, with zero downtime.
 
 ![Tools for schema migrations](/images/zdt-schema-xata.png)
 


### PR DESCRIPTION
## Summary

`pgroll` docs have been split into several files in https://github.com/xataio/pgroll/pull/499. 

Update the links in old `pgroll` blog posts so that they work with the new docs structure.