### PR TITLE
Add canonical URLs for the duplicate blog posts on pgroll.com

### DIFF
--- a/database-schema-design.mdx
+++ b/database-schema-design.mdx
@@ -9,6 +9,7 @@ date: 08-04-2023
 tags: ['database', 'schema', 'data', 'modeling']
 published: true
 slug: database-schema-design
+canonicalUrl: https://pgroll.com/blog/database-schema-design
 ---
 
 **Picture this:** You're a developer working on a new project, and everything seems perfect until you realize your data is scattered all over the place and your code can’t access it efficiently! It feels like a never-ending treasure hunt, and you're racing against time to find the right information. But wait, could this very time-consuming and chaotic situation have been avoided? By planning and organizing, could all of that scattered information have been consolidated?

--- a/introducing-pgroll.mdx
+++ b/introducing-pgroll.mdx
@@ -11,6 +11,7 @@ tags: ['open-source', 'postgres', 'fpSchemaMigrations', 'fpPgroll', 'fpPgzx', 'o
 published: true
 slug: pgroll-schema-migrations-postgres
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/introducing-pgroll.jpg
+canonicalUrl: https://pgroll.com/blog/introducing-pgroll-zero-downtime-reversible-schema-migrations-for-postgres
 ---
 
 ## Schema migrations are painful

--- a/pgroll-integration.mdx
+++ b/pgroll-integration.mdx
@@ -11,6 +11,7 @@ image:
   alt: 'pgroll Integration'
 slug: pgroll-postgres-xata-integration
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-integration/pgroll-blog-header.jpeg
+canonicalUrl: https://pgroll.com/blog/powering-up-schema-migrations-with-pgroll
 ---
 
 In a typical development workflow, schema changes to an application’s database can take a long time, and rollbacks are often error prone. That’s why we’ve created [pgroll](https://github.com/xataio/pgroll) - an open source Postgres tool for zero-downtime and reversible schema migrations.

--- a/pgroll-internals.mdx
+++ b/pgroll-internals.mdx
@@ -11,6 +11,7 @@ tags: ['open-source', 'postgres', 'schema', 'fpPgroll', 'fpPgzx', 'oss']
 published: true
 slug: pgroll-internals
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-internal.jpeg
+canonicalUrl: https://pgroll.com/blog/inside-pgroll-how-it-works-under-the-hood
 ---
 
 At the start of October we released [pgroll](https://github.com/xataio/pgroll), an open source tool for [zero-downtime, reversible schema migrations for Postgres](https://xata.io/blog/pgroll-schema-migrations-postgres).

--- a/postgres-migrations-locking-and-backoff.mdx
+++ b/postgres-migrations-locking-and-backoff.mdx
@@ -11,6 +11,7 @@ tags: ['open-source', 'postgres', 'schema', 'fpPgroll', 'fpSchemaMigrations', 'o
 published: true
 slug: migrations-and-exclusive-locks
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-migration-locks.png
+canonicalUrl: https://pgroll.com/blog/schema-changes-and-the-postgres-lock-queue
 ---
 
 Schema changes are hard. They're hard because there are multiple different failure modes, some of which require knowledge of how the underlying RDBMS system works, especially with regard to object locking.

--- a/postgres-schema-changes-pita.mdx
+++ b/postgres-schema-changes-pita.mdx
@@ -10,6 +10,7 @@ date: 06-29-2023
 tags: ['engineering', 'postgres', 'fpSchemaMigrations']
 published: true
 slug: postgres-schema-changes-pita
+canonicalUrl: https://pgroll.com/blog/postgres-schema-changes-are-still-a-pita
 ---
 
 We software engineers don’t agree on much, but we agree on this one: database schema changes are a pain in the a\*\*.

--- a/schema-changes-expand-contract-method.mdx
+++ b/schema-changes-expand-contract-method.mdx
@@ -11,6 +11,7 @@ tags: ['open-source', 'postgres', 'schema', 'migrations', 'pgroll', 'fpSchemaMig
 published: true
 slug: pgroll-expand-contract
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgconf-eu-pgroll-talk-recap-og@2x.png
+canonicalUrl: https://pgroll.com/blog/schema-changes-and-the-power-of-expand-contract-with-pgroll
 ---
 
 Schema changes have a reputation. They’re the kind of task that strikes fear into even the most seasoned developers. Downtime, breaking changes, and complex rollbacks can turn an otherwise smooth deployment into a high-stakes game of database roulette.

--- a/schema-multiversion-launch-week.mdx
+++ b/schema-multiversion-launch-week.mdx
@@ -21,6 +21,7 @@ tags:
 published: true
 slug: multi-version-schema-migrations
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/schema-multi-version@2x.jpg
+canonicalUrl: https://pgroll.com/blog/introducing-multi-version-schema-migrations
 ---
 
 Today we are excited to announce multi-version schema migrations in Xata, which utilizes our open-source library [pgroll](https://github.com/xataio/pgroll) under the hood. 🎉

--- a/whats-new-in-pgroll-0-6-0.mdx
+++ b/whats-new-in-pgroll-0-6-0.mdx
@@ -11,6 +11,7 @@ tags: ['open-source', 'postgres', 'schema', 'migrations', 'pgroll', 'fpSchemaMig
 published: true
 slug: pgroll-0-6-0-update
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-update-0-6-0@2x.jpg
+canonicalUrl: https://pgroll.com/blog/pgroll-060-update
 ---
 
 [pgroll](https://xata.io/pgroll) is Xata's open-source schema migration tool for Postgres. The feature that sets it apart from other migration tools is its ability to perform multi-version schema migrations using the expand/contract pattern: while a migration is in progress, `pgroll` is able to present two versions of your database schema to client applications - the old version and the new. This means that client applications that depend on the old version of the database schema continue to function while the migration is in progress, making application deployments much simpler. Gone are the days of having to perform [complicated multi-step workflows](https://planetscale.com/docs/learn/handling-table-and-column-renames#how-to-rename-a-column-on-planetscale) to do simple schema changes without breaking clients.

--- a/whats-new-in-pgroll-0-7-0.mdx
+++ b/whats-new-in-pgroll-0-7-0.mdx
@@ -11,6 +11,7 @@ tags: ['open-source', 'postgres', 'schema', 'migrations', 'pgroll', 'fpSchemaMig
 published: true
 slug: pgroll-0-7-0-update
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/pgroll-update-0-6-0@2x.jpg
+canonicalUrl: https://pgroll.com/blog/pgroll-070-update
 ---
 
 [pgroll](https://xata.io/pgroll) is Xata's open-source schema migration tool for Postgres, built to enable zero downtime, reversible schema migrations using the expand/contract pattern. `pgroll` is open-source under the Apache-2.0 license and developed in the open on [GitHub](https://github.com/xataio/pgroll).

--- a/zero-downtime-schema-migrations-postgresql.mdx
+++ b/zero-downtime-schema-migrations-postgresql.mdx
@@ -10,6 +10,7 @@ tags: ['workshop', 'pgroll', 'fpSchemaMigrations', 'fpPgroll', 'oss']
 published: true
 slug: zero-downtime-schema-migrations-postgresql
 ogImage: https://raw.githubusercontent.com/xataio/mdx-blog/main/images/zdt-illustration.jpeg
+canonicalUrl: https://pgroll.com/blog/how-to-perform-postgres-schema-changes-in-production-with-zero-downtime
 ---
 
 <ArticleVideo platform="youtube" src="https://www.youtube.com/embed/-1aO6UznfI0?si=qLv09ZanA_UMQf0w" />


### PR DESCRIPTION
## Summary

This is a pair PR with https://github.com/xataio/frontend-next/pull/4057

We need to merge them both to see it in action. I did test locally though.

### Blog Release Checklist

- \[ ] Release on: \<mm/dd/yy>
- \[ ] Published on dev.to (connected to Xata org)
- \[ ] OG image included
- \[ ] Social media is scheduled for this post
