### PR TITLE
fix links on pgroll v0.12.0 page

### DIFF
--- a/whats-new-in-pgroll-0-12-0.mdx
+++ b/whats-new-in-pgroll-0-12-0.mdx
@@ -16,9 +16,9 @@ canonicalUrl: https://pgroll.com/blog/pgroll-0120-update
 
 We've just released `v0.12` of `pgroll`, our open-source schema migration tool for Postgres. As we've done for previous releases, we'll take a look at some of the headline features that made it into the release and look ahead to what's coming next. Past entries in the release blog series can be read here:
 
-- [pgroll v0.11 release blog](https://pgroll.com/blog/pgroll-0-11-0-update)
-- [pgroll v0.10 release blog](https://pgroll.com/blog/pgroll-0-10-0-update)
-- [pgroll v0.9 release blog](https://pgroll.com/blog/pgroll-0-9-0-update)
+- [pgroll v0.11 release blog](https://pgroll.com/blog/pgroll-0110-update)
+- [pgroll v0.10 release blog](https://pgroll.com/blog/pgroll-0100-update)
+- [pgroll v0.9 release blog](https://pgroll.com/blog/pgroll-09-update)
 
 For the complete notes for this release see the [Github v0.12.0 release page](https://github.com/xataio/pgroll/releases/tag/v0.12.0).
 


### PR DESCRIPTION
## Summary

Fix the links in pgroll v0.12.0 blog post.

### Blog Release Checklist

- \[ ] Release on: \<mm/dd/yy>
- \[ ] Published on dev.to (connected to Xata org)
- \[ ] OG image included
- \[ ] Social media is scheduled for this post
